### PR TITLE
fix: prevent whitespace-only message submission and add default session

### DIFF
--- a/src/devtools/App.tsx
+++ b/src/devtools/App.tsx
@@ -423,10 +423,10 @@ function MessageInput(props: {
         if (event) {
             event.preventDefault()
         }
-        if (messageInput.length === 0) {
+        if (messageInput.trim().length === 0) {
             return
         }
-        props.onSubmit(createMessage('user', messageInput))
+        props.onSubmit(createMessage('user', messageInput.trim()))
         setMessageInput('')
     }
     return (

--- a/src/devtools/defaults.ts
+++ b/src/devtools/defaults.ts
@@ -2,6 +2,11 @@ import { Session } from './types'
 
 export const sessions: Session[] = [
     {
+        "id": "00000000-0000-0000-0000-000000000001",
+        "name": "My First Chat",
+        "messages": []
+    },
+    {
         "id": "1bc7094f-1248-4b51-8ac8-180a5a1470aa",
         "name": "Random Talk",
         "messages": [


### PR DESCRIPTION

<img width="1277" height="761" alt="before" src="https://github.com/user-attachments/assets/222c4666-ef47-47cc-8958-38c6a41f8de5" />
<img width="1276" height="763" alt="after" src="https://github.com/user-attachments/assets/da58bb9d-8741-4181-8064-8063a7b25b1f" />

- Added .trim() validation to MessageInput component
- Auto-trim leading/trailing whitespace from valid messages
- Preserves internal whitespace and multi-line functionality

Note: this commit also has a getting started issue fixed
- Added default 'My First Chat' session to defaults


video link: https://youtu.be/heTWCGRTwZs