### PR TITLE
Feat/copy code block

### DIFF
--- a/src/devtools/App.tsx
+++ b/src/devtools/App.tsx
@@ -423,10 +423,10 @@ function MessageInput(props: {
         if (event) {
             event.preventDefault()
         }
-        if (messageInput.length === 0) {
+        if (messageInput.trim().length === 0) {
             return
         }
-        props.onSubmit(createMessage('user', messageInput))
+        props.onSubmit(createMessage('user', messageInput.trim()))
         setMessageInput('')
     }
     return (

--- a/src/devtools/Block.tsx
+++ b/src/devtools/Block.tsx
@@ -65,6 +65,7 @@ function _Block(props: Props) {
     const { msg, setMsg } = props
     const [isHovering, setIsHovering] = useState(false)
     const [isEditing, setIsEditing] = useState(false)
+    const messageRef = useRef<HTMLDivElement>(null)
 
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
     const open = Boolean(anchorEl);
@@ -75,6 +76,85 @@ function _Block(props: Props) {
         setAnchorEl(null);
     };
 
+    // Detect and enhance code blocks after markdown rendering
+    useEffect(() => {
+        if (!messageRef.current || isEditing) return;
+
+        // Use setTimeout to ensure dangerouslySetInnerHTML has rendered
+        const timer = setTimeout(() => {
+            const codeBlocks = messageRef.current?.querySelectorAll('pre.hljs');
+            if (!codeBlocks || codeBlocks.length === 0) return;
+
+            codeBlocks.forEach((block) => {
+                const codeElement = block.querySelector('code');
+                if (!codeElement) return;
+
+                // Extract clean text content
+                const codeText = codeElement.textContent || '';
+
+                // Check if already wrapped
+                const existingWrapper = (block.parentElement as HTMLElement);
+                if (existingWrapper?.classList.contains('code-block-wrapper')) {
+                    return; // Already wrapped, CSS handles theme changes
+                }
+
+                // Create wrapper div
+                const wrapper = document.createElement('div');
+                wrapper.className = 'code-block-wrapper';
+
+                // Create copy button
+                const copyButton = document.createElement('button');
+                copyButton.className = 'code-copy-button';
+                copyButton.setAttribute('aria-label', 'Copy code to clipboard');
+                copyButton.title = 'Copy code';
+                copyButton.innerHTML = `
+                    <svg viewBox="0 0 24 24">
+                        <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/>
+                    </svg>
+                `;
+
+                // Copy functionality
+                copyButton.addEventListener('click', async () => {
+                    try {
+                        await navigator.clipboard.writeText(codeText);
+                        // Success feedback
+                        copyButton.classList.add('copied');
+                        copyButton.innerHTML = `
+                            <svg viewBox="0 0 24 24">
+                                <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/>
+                            </svg>
+                        `;
+                        copyButton.setAttribute('aria-label', 'Code copied!');
+                        
+                        setTimeout(() => {
+                            copyButton.classList.remove('copied');
+                            copyButton.innerHTML = `
+                                <svg viewBox="0 0 24 24">
+                                    <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/>
+                                </svg>
+                            `;
+                            copyButton.setAttribute('aria-label', 'Copy code to clipboard');
+                        }, 2000);
+                    } catch (err) {
+                        // Error feedback
+                        copyButton.classList.add('error');
+                        copyButton.setAttribute('aria-label', 'Failed to copy');
+                        setTimeout(() => {
+                            copyButton.classList.remove('error');
+                            copyButton.setAttribute('aria-label', 'Copy code to clipboard');
+                        }, 2000);
+                    }
+                });
+
+                // Wrap the code block
+                block.parentNode?.insertBefore(wrapper, block);
+                wrapper.appendChild(block);
+                wrapper.appendChild(copyButton);
+            });
+        }, 0);
+        
+        return () => clearTimeout(timer);
+    }, [msg.content, isEditing]);
 
     const tips: string[] = []
     if (props.showWordCount) {
@@ -151,6 +231,7 @@ function _Block(props: Props) {
                                     />
                                 ) : (
                                     <Box
+                                        ref={messageRef}
                                         sx={{
                                             // bgcolor: "Background",
                                         }}

--- a/src/devtools/defaults.ts
+++ b/src/devtools/defaults.ts
@@ -2,6 +2,11 @@ import { Session } from './types'
 
 export const sessions: Session[] = [
     {
+        "id": "00000000-0000-0000-0000-000000000001",
+        "name": "My First Chat",
+        "messages": []
+    },
+    {
         "id": "1bc7094f-1248-4b51-8ac8-180a5a1470aa",
         "name": "Random Talk",
         "messages": [

--- a/src/index.scss
+++ b/src/index.scss
@@ -100,3 +100,89 @@ html[data-theme='light'] {
         display: none;
     }
 }
+
+// ------------ Code Block Copy Button ---------------
+
+.code-block-wrapper {
+    position: relative;
+    margin-bottom: 1em;
+    display: block;
+    width: 100%;
+}
+
+.code-block-wrapper pre {
+    margin: 0;
+    position: relative;
+    padding-right: 58px; // Extra space for button
+}
+
+.code-copy-button {
+    position: absolute !important;
+    top: 8px !important;
+    right: 8px !important;
+    border-radius: 6px;
+    padding: 8px;
+    cursor: pointer;
+    display: inline-flex !important;
+    align-items: center;
+    justify-content: center;
+    opacity: 0;
+    transition: all 0.2s ease-in-out;
+    z-index: 9999 !important;
+    min-width: 34px;
+    min-height: 34px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    margin: 0 !important;
+    left: auto !important;
+    transform-origin: center;
+    
+    svg {
+        width: 18px;
+        height: 18px;
+        fill: currentColor;
+    }
+    
+    &:hover {
+        transform: scale(1.05);
+    }
+    
+    &.copied {
+        background: rgba(76, 175, 80, 0.9) !important;
+        color: #fff !important;
+    }
+    
+    &.error {
+        background: rgba(244, 67, 54, 0.9) !important;
+        color: #fff !important;
+    }
+}
+
+.code-block-wrapper:hover .code-copy-button {
+    opacity: 1;
+}
+
+// Dark theme styles
+html[data-theme='dark'] {
+    .code-copy-button {
+        background: rgba(255, 255, 255, 0.15);
+        color: rgba(255, 255, 255, 0.9);
+        border: 1px solid rgba(255, 255, 255, 0.3);
+        
+        &:hover {
+            background: rgba(255, 255, 255, 0.25);
+        }
+    }
+}
+
+// Light theme styles
+html[data-theme='light'] {
+    .code-copy-button {
+        background: rgba(0, 0, 0, 0.08);
+        color: rgba(0, 0, 0, 0.7);
+        border: 1px solid rgba(0, 0, 0, 0.15);
+        
+        &:hover {
+            background: rgba(0, 0, 0, 0.15);
+        }
+    }
+}


### PR DESCRIPTION
- Adding a new copy code button feature to code blocks rendered in the chatbox conversations.

before:
<img width="683" height="254" alt="before" src="https://github.com/user-attachments/assets/2b9876b6-6b0d-4216-a561-08829d3a6490" />

after:
<img width="678" height="257" alt="after" src="https://github.com/user-attachments/assets/5a150076-517d-4421-9fce-e7e910f9d937" />

- The copy code button also shows a visual indication after the code is copied.

Video:

https://github.com/user-attachments/assets/a5888acb-9846-47e0-8172-5e0c15c22d80


